### PR TITLE
Use 23.04 craft cache version as pixman is not (yet) available in 23.07

### DIFF
--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -31,6 +31,7 @@ ShortPath/EnableJunctions = False
 ; Packager/RepositoryUrl = https://files.kde.org/craft/
 Packager/PackageType = NullsoftInstallerPackager
 Packager/RepositoryUrl = http://ftp.acc.umu.se/mirror/kde.org/files/craft/master/
+Packager/CacheVersion = 23.04
 
 ContinuousIntegration/Enabled = True
 


### PR DESCRIPTION
KDE recently switched the default cache version from 23.04 to 23.07 (see https://github.com/KDE/craft/commit/a860e1889640a337d8809c2d515e6345a1c5fd72). This new version does not include (yet?) the pixman libraries (see https://files.kde.org/craft/master/23.07/windows/cl/msvc2019/x86_64/RelWithDebInfo).

Advantage of using a fixed version is that new PR will not start to fail due to an upstream change.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
